### PR TITLE
feat: implement basic utxo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +33,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "const-oid"
@@ -43,6 +67,12 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crypto-bigint"
@@ -124,6 +154,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +202,7 @@ name = "grok-chain"
 version = "0.1.0"
 dependencies = [
  "k256",
+ "postcard",
  "serde",
  "serde_json",
  "thiserror",
@@ -174,6 +217,29 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -213,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +307,19 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -272,10 +360,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -291,6 +394,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -367,6 +476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +493,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grok-chain"
 authors = ["Sabaun Taraki <sabaun.dev@gmail.com>"]
 description = "A simple blockchain implementation in Rust."
-repository = "https://github.com/techraed/grock-chain"
+repository = "https://github.com/techraed/grok-chain"
 readme = "README.md"
 version = "0.1.0"
 edition = "2024"
@@ -14,6 +14,7 @@ path = "bin/main.rs"
 
 [dependencies]
 k256 = { version = "0.13.4", features = ["serde"] }
+postcard = { version = "1.1.3", features = ["use-std"]}
 serde ={ version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,19 @@
+// Copyright 2025 Sabaun Taraki
+// SPDX-License-Identifier: Apache-2.0
+
+//! Encoding and decoding functionalities for Grok Chain.
+
+#![allow(dead_code)]
+
+use crate::errors::CodecError;
+use serde::{Deserialize, Serialize};
+
+/// Encodes the given data into a byte vector using `postcard` serialization.
+pub fn encode<T: Serialize + ?Sized>(data: &T) -> Result<Vec<u8>, CodecError> {
+    postcard::to_allocvec(data).map_err(CodecError::SerializationFailed)
+}
+
+/// Decodes the given byte slice into the specified type using `postcard` deserialization.
+pub fn decode<'a, T: Deserialize<'a>>(s: &'a [u8]) -> Result<T, CodecError> {
+    postcard::from_bytes(s).map_err(CodecError::DeserializationFailed)
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,8 @@
 pub enum GrokChainError {
     #[error("Cryptography error: {0}")]
     Crypto(#[from] CryptoError),
+    #[error("Codec error: {0}")]
+    Codec(#[from] CodecError),
 }
 
 /// Cryptography related errors.
@@ -20,4 +22,20 @@ pub enum CryptoError {
     MessageSigningFailed(k256::ecdsa::Error),
     #[error("Failed to verify message signature: {0}")]
     MessageVerificationFailed(k256::ecdsa::Error),
+}
+
+/// Transaction related errors.
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionError {
+    #[error("Failed to serialize transaction: {0}")]
+    FailedTransactionSerialization(#[from] CodecError),
+}
+
+/// Codec related errors
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    #[error("Failed to serialize data: {0}")]
+    SerializationFailed(postcard::Error),
+    #[error("Failed to deserialize data: {0}")]
+    DeserializationFailed(postcard::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright 2025 Sabaun Taraki
 // SPDX-License-Identifier: Apache-2.0
 
+mod codec;
 mod crypto;
 mod errors;
+mod transaction;
 
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,162 @@
+// Copyright 2025 Sabaun Taraki
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transactions structure and related functionalities.
+
+// TODO : temporarily
+#![allow(dead_code)]
+
+use crate::{
+    codec,
+    crypto::{Hash256, PublicKey, Signature},
+    errors::TransactionError,
+};
+use serde::{Deserialize, Serialize};
+
+/// Heinlein is the smallest unit of currency.
+///
+/// The name is inspired by Robert A. Heinlein, a science fiction author, who
+/// actually coined the term "grok", which stands for "to understand deeply and
+/// intuitively".
+const HEINLEIN: u64 = 1;
+
+/// Grok is the main currency unit.
+///
+/// 1 Grok = 1,000,000,000 Heinleins.
+/// Heinlein is needed to avoid floating point precision issues.
+/// So 0.000000001 Grok = 1 Heinlein.
+const GROK: u64 = 1_000_000_000 * HEINLEIN;
+
+/// Grok chain UTXO transaction.
+///
+/// A UTXO transaction is basically:
+/// - A list of inputs ([`TransactionInput`]);
+/// - A list of outputs ([`TransactionOutput`]);
+/// - An identifier ([`TransactionId`]).
+///
+/// UTXO-based transactions can be compared to bills of exchange, or, more precisely, checks from
+/// the traditional banking system. Each input in a UTXO transaction represents a claim on a specific
+/// output from a previous transaction, similar to how a check represents a claim on funds from a
+/// bank account. The outputs of the transaction specify new claims on funds, akin to how a check
+/// specifies the amount to be paid to the recipient. Outputs are like new checks created by the
+/// transaction sender, which can be redeemed by the recipients specified in the outputs. The receipient
+/// then can use those outputs as inputs in future transactions.
+///
+/// The description above looks like we are designing the processing and transferring system, but where
+/// is the actual money? The actual money is represented by the amount field in the outputs. The UTXO transaction
+/// system can be compared to the process of purchasing a land. The seller doesn't bring the acres you are buying
+/// as it's, obviously, impossible. Instead, the seller provides you with a legal document, signing of which
+/// creates a transaction of giving you the ownership of the land. That's the whole idea of any electronic transaction
+/// system - you just give ownership of some value to someone else.
+///
+/// *Note*: transaction outputs primary for the system, as inputs always refer to previous outputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    pub inputs: Vec<TransactionInput>,
+    pub outputs: Vec<TransactionOutput>,
+    pub id: TransactionId,
+}
+
+impl Transaction {
+    /// Creates a new transaction from inputs and outputs.
+    ///
+    /// Basically encodes the raw transaction, which consists of inputs and outputs, and computes identifier
+    /// over the serialized bytes.
+    pub fn new(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<TransactionOutput>,
+    ) -> Result<Self, TransactionError> {
+        let tx_bytes = codec::encode(&(&inputs, &outputs))?;
+        let id = TransactionId(Hash256::new(tx_bytes));
+
+        Ok(Self {
+            inputs,
+            outputs,
+            id,
+        })
+    }
+}
+
+/// Transaction identifier.
+///
+/// A transaction identifier is a 32 bytes hash of the inputs and outputs.
+///
+/// *Note*: The identifier isn't possible to be instantiated directly, only through
+/// creating a transaction.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct TransactionId(Hash256);
+
+impl TransactionId {
+    /// Returns the inner hash.
+    pub fn inner(&self) -> Hash256 {
+        self.0
+    }
+}
+
+/// Transaction input.
+///
+/// Refers to a previous transaction output by its identifier and index.
+///
+/// The index is the position of the output in the previous transaction's outputs list.
+/// The signature is used to prove ownership of the output being spent. It's basically a signature
+/// over the challenge data in the transaction output being spent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionInput {
+    pub tx_id: TransactionId,
+    pub idx: usize,
+    pub signature: Signature,
+}
+
+/// Transaction output.
+///
+/// Transaction output is a primary component of UTXO-based transaction systems.
+/// It represents a specific amount of currency assigned to a public key (ownership).
+/// The challenge field is an arbitrary data that a spender must sign to prove ownership of the output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionOutput {
+    pub amount: u64,
+    pub ownership: PublicKey,
+    pub challenge: [u8; 32],
+}
+
+#[cfg(test)]
+mod tests {
+    use k256::elliptic_curve::rand_core::{RngCore, OsRng};
+    use super::*;
+
+    // Test that `encode` gives us expected data.
+    #[test]
+    fn codec_smoke_test() {
+        let pk = crate::crypto::PrivateKey::random();
+        let pub_key = PublicKey::from(&pk);
+        let signature = pk
+            .sign(b"test transaction")
+            .expect("internal error: signing failed");
+
+        let tx_input = TransactionInput {
+            tx_id: TransactionId(Hash256::new(b"transaction id")),
+            idx: 1,
+            signature,
+        };
+        let encoded = codec::encode(&tx_input).expect("internal error: encoding failed");
+        let decoded =
+            codec::decode::<TransactionInput>(&encoded).expect("internal error: decoding failed");
+        assert_eq!(tx_input.tx_id.inner(), decoded.tx_id.inner());
+        assert_eq!(tx_input.idx, decoded.idx);
+        assert_eq!(tx_input.signature.to_bytes(), decoded.signature.to_bytes());
+
+        let mut random_challenge = [0u8; 32];
+        OsRng.fill_bytes(&mut random_challenge);
+        let tx_output = TransactionOutput {
+            amount: 2 * GROK,
+            ownership: pub_key,
+            challenge: random_challenge,
+        };
+        let encoded = codec::encode(&tx_output).expect("internal error: encoding failed");
+        let decoded =
+            codec::decode::<TransactionOutput>(&encoded).expect("internal error: decoding failed");
+        assert_eq!(tx_output.amount, decoded.amount);
+        assert_eq!(tx_output.ownership.to_bytes(), decoded.ownership.to_bytes());
+        assert_eq!(tx_output.challenge, decoded.challenge);
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -121,8 +121,8 @@ pub struct TransactionOutput {
 
 #[cfg(test)]
 mod tests {
-    use k256::elliptic_curve::rand_core::{RngCore, OsRng};
     use super::*;
+    use k256::elliptic_curve::rand_core::{OsRng, RngCore};
 
     // Test that `encode` gives us expected data.
     #[test]


### PR DESCRIPTION
# Overview

This module introduces a UTXO-style transaction model in `transaction` module, plus a compact serialization layer in `codec` module. The goal is to define how value moves (via inputs/outputs) and how those structures are serialized for hashing, storage, and network transfer.

### Why encoding/decoding exists (and why it matters)

Encoding and decoding format are crucial parts of any blockchain project, because literally any transmittable data (transactions, blocks) are sent/received as bytes to/from p2p network, so encoding2. But that's not the only reason why codec is important. The other reason is about DB compactness - smaller encodings reduce storage and increase read speed. 

We currently use Postcard via `codec::encode`/`codec::decode`, which is compact and fast enough for a first iteration. Other widely-used blockchain encodings (for context):
- Ethereum RLP
- Parity SCALE (Substrate/Polkadot)
- Bitcoin’s wire format (varints, little-endian fields)

Btw, `Protobuf` / `FlatBuffers` / `Cap’n Proto` are also common in distributed systems, though less common for L1 canonical tx encoding.

## UTXO model

A Transaction is
```rust
struct Transaction {
    inputs: Vec<TransactionInput> 
    outputs: Vec<TransactionOutput>
    id: TransactionId
}
```

**Outputs are primary**. Each output is a new “claim” on value:
```rust
pub struct TransactionOutput {
    pub amount: u64,
    pub ownership: PublicKey,
    pub challenge: [u8; 32],
}
```

The smallest amount unit is called `heinlein` (a tribute to Robert Heinlein and his neologism _grok_). `ownership` is the public key that can spend `amount`. `challenge` is an arbitrary data that must be signed to prove ownership.

**Inputs spend previous outputs**
```rust
pub struct TransactionInput {
    pub tx_id: TransactionId,
    pub idx: usize,
    pub signature: Signature,
}
```
`tx_id` and `idx` identify the specific prior output, while `signature` proves the spender owns the output by signing its challenge.

`TransactionId` is a hash of serialized inputs+outputs. This makes the ID deterministic and tied to the exact content. `TransactionId` cannot be instantiated directly. The only legitimate way to get a `TransactionId` is via `Transaction::new`, which hashes the canonical serialized transaction. This is critical because it prevents arbitrary `txids and ensures the ID is always derivable from content.

### Current shortcomings / risks to highlight
1. Authorization validation gap
There’s no sender identity in UTXO by design, which is fine. But security depends entirely on validating that the input signature must correspond to the ownership key of the referenced output. Today, nothing in this module enforces that linkage. Worse, if a wallet mistakenly reuses the same `(public_key, challenge)` in another output, an attacker could produce a valid signature for that challenge (or replay an old signature) and steal value.
2. Possible transaction malleability
Because `TransactionId` is a hash of serialized inputs/outputs, any divergence in serialization (version mismatch, alternate encoder, or signing a different preimage) can produce different txids for the same semantic transaction. Postcard is deterministic for a fixed layout, so malleability is unlikely unless serialization changes or signatures are computed over different bytes.
