### PR TITLE
feat: implement blockchain storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,10 +75,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
@@ -176,6 +206,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +254,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
+ "sled",
  "thiserror",
 ]
 
@@ -252,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +363,31 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "pkcs8"
@@ -347,6 +437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -476,6 +575,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +681,28 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -176,7 +176,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle",
@@ -201,7 +201,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -247,11 +247,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "grok-chain"
 version = "0.1.0"
 dependencies = [
  "k256",
  "postcard",
+ "rand",
  "serde",
  "serde_json",
  "sled",
@@ -265,7 +278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -413,6 +426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,12 +453,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -571,7 +628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -683,6 +740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +769,32 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "bin/main.rs"
 [dependencies]
 k256 = { version = "0.13.4", features = ["serde"] }
 postcard = { version = "1.1.3", features = ["use-std"]}
+sled = "0.34.7"
 serde ={ version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ sled = "0.34.7"
 serde ={ version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
+
+[dev-dependencies]
+rand = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ struct Block {
 - [x] Signing transactions.
 - [x] Verifying signatures.
 2. Transactions UTXO model
-- [ ] Basic UTXO structure
-- [ ] Transaction creation, validation, execution
+- [x] Basic UTXO structure
+- [x] Transaction creation, validation, execution
 3. Persistence layer (using `sled` crate) - SECTION TBD
 - [ ] Storing blocks
 - [ ] Storing UTXOs

--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ struct Block {
 2. Transactions UTXO model
 - [x] Basic UTXO structure
 - [x] Transaction creation, validation, execution
-3. Persistence layer (using `sled` crate) - SECTION TBD
-- [ ] Storing blocks
-- [ ] Storing UTXOs
+3. Persistence layer (using `sled` crate)
+- [x] Storing blocks
+- [x] Storing UTXOs
 4. Block format
-- [ ] Merkle tree for transactions
-- [ ] Block header with timestamp, nonce, previous block hash
-- [ ] Block verification, application and revocation
+- ~~[ ] Merkle tree for transactions~~ **UPD: postponed**
+- [x] Block header with timestamp, nonce, previous block hash
+- [x] Block verification, application and revocation
 5. Networking layer
-6. Sync and fork handling
-7. Performance and observability
+- [ ] Handshakes (establishing connection)
+- [ ] Peer discovery
+- [ ] Block and transaction propagation
+6. Mining, sync and fork handling
 
 ### Stage 3 – Implementation of a virtual machine and smart contracts
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,0 +1,126 @@
+// Copyright 2025 Sabaun Taraki
+// SPDX-License-Identifier: Apache-2.0
+
+//! Block structure and related functionalities.
+
+// TODO : temporarily
+#![allow(dead_code)]
+
+use crate::{
+    codec, crypto::Hash256, db::Database, errors::{BlockChainError, DatabaseError}, transaction::{self, Transaction}
+};
+use serde::{Deserialize, Serialize};
+
+/// Applies a valid block to the blockchain.
+pub fn apply_block(block: Block, db: &Database) -> Result<(), BlockChainError> {
+    for tx in &block.transactions {
+        // todo [sab]: get rid of clone
+        transaction::execute_tx(tx.clone(), db)
+            .map_err(|tx_err| BlockChainError::InvalidTransaction(tx.id.inner(), tx_err))?;
+    }
+
+    let block_hash = Block::block_hash(&block)?;
+
+    db
+        .insert_block(block_hash, block)
+        .map_err(|db_err| BlockChainError::FailedToStoreBlock(db_err))
+}
+
+pub fn revert_block(block_hash: Hash256, db: &Database) -> Result<Block, BlockChainError> {
+    let block = db
+        .remove_block(block_hash)
+        .map_err(|db_err| BlockChainError::FailedToRemoveBlock(db_err))?;
+
+    for tx in block.transactions.iter() {
+        // todo [sab]: get rid of clone
+        transaction::revert_tx(tx.clone(), db)
+            .map_err(|tx_err| BlockChainError::InvalidTransaction(tx.id.inner(), tx_err))?;
+    }
+
+    let block_hash = Block::block_hash(&block)?;
+
+    db.remove_block(block_hash)
+        .map_err(|db_err| BlockChainError::FailedToStoreBlock(db_err))
+}
+
+/// Validates a block.
+///
+/// Basically checks:
+/// 1. Previous block exists in the database.
+/// 2. All transactions in the block are valid.
+pub fn validate_block(block: &Block, db: &Database) -> Result<(), BlockChainError> {
+    match db.block(block.previous_block_hash) {
+        Err(DatabaseError::BlockNotFound(_)) => {
+            return Err(BlockChainError::OrphanBlockReceived(
+                block.previous_block_hash,
+            ));
+        }
+        Err(db_err) => {
+            return Err(BlockChainError::CannotGetBlock(
+                block.previous_block_hash,
+                db_err,
+            ));
+        }
+        _ => {}
+    };
+
+    for tx in &block.transactions {
+        transaction::validate_tx(tx, db)
+            .map_err(|tx_err| BlockChainError::InvalidTransaction(tx.id.inner(), tx_err))?;
+    }
+
+    Ok(())
+}
+
+/// Block structure representing a single block in the blockchain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Block {
+    pub previous_block_hash: Hash256,
+    pub block_number: u32,
+    pub block_timestamp: u64,
+    pub transactions: Vec<Transaction>,
+}
+
+impl Block {
+    pub fn new(
+        previous_block_hash: Hash256,
+        db: &Database,
+        tx_mempool: &mut Vec<Transaction>,
+    ) -> Result<Self, BlockChainError> {
+        let previous_block = db
+            .block(previous_block_hash)
+            .map_err(|db_err| BlockChainError::CannotGetBlock(previous_block_hash, db_err))?;
+        let block_number = previous_block.block_number.saturating_add(1);
+
+        let transactions = if tx_mempool.is_empty() {
+            Vec::new()
+        } else {
+            // First 10 transactions from mempool
+            let end = tx_mempool.len().min(10);
+            tx_mempool.drain(0..end).collect()
+        };
+
+        Ok(Self {
+            previous_block_hash,
+            block_number,
+            block_timestamp: now_secs(),
+            transactions,
+        })
+    }
+
+    pub fn block_hash(block: &Self) -> Result<Hash256, BlockChainError> {
+        let block_bytes = codec::encode(block)
+            .map_err(BlockChainError::FailedBlockSerialization)?;
+
+        Ok(Hash256::new(block_bytes))
+    }
+}
+
+fn now_secs() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs()
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -26,18 +26,22 @@ pub fn apply_block(
 
     let mut data_operations = Vec::new();
 
+    // Apply all transactions in the block
     for tx in &block.transactions {
         let mut ops = apply_tx(tx)?;
         data_operations.append(&mut ops);
     }
 
+    // Finally, insert the block itself
     data_operations.push(DatabaseOperation::InsertBlock { block_hash, block });
 
+    // Execute all operations in a single transaction
     let outcomes = db
         .transactional_ops(data_operations)
         .map_err(|db_err| BlockChainError::FailedToApplyBlock(block_hash, db_err))?;
 
     // todo [sab] recovery storage is tightly connected to transaction. It must be changed even inside the transaction
+    // Store removed data for recovery in case of a reorg.
     for outcome in outcomes {
         let DatabaseOperationOutcome::RemoveTxOutput { tx_id, idx, output } = outcome else {
             continue;
@@ -77,41 +81,52 @@ fn apply_tx(tx: &Transaction) -> Result<Vec<DatabaseOperation>, BlockChainError>
 }
 
 pub fn revert_block(
-    _block_hash: Hash256,
-    _db: &Database,
-    _recovery_store: &mut BTreeMap<Hash256, BlockRecoveryData>,
+    block_hash: Hash256,
+    db: &Database,
+    recovery_store: &mut BTreeMap<Hash256, BlockRecoveryData>,
 ) -> Result<Block, BlockChainError> {
-    // let block = db
-    //     .remove_block(block_hash)
-    //     .map_err(BlockChainError::FailedToRemoveBlock)?;
+    let mut data_operations = Vec::new();
 
-    // for tx in &block.transactions {
-    //     revert_tx(tx, db)?;
-    // }
+    // The retrieval is a compromise, as there is no way to get the block data
+    // from the operations only.
+    let block = db
+        .block(block_hash)
+        .map_err(|db_err| BlockChainError::CannotGetBlock(block_hash, db_err))?;
 
-    // let block_recovery = recovery_store
-    //     .remove(&block_hash)
-    //     .unwrap_or_else(|| unreachable!("Block recovery data not found"));
+    // Remove the block itself
+    data_operations.push(DatabaseOperation::RemoveBlock { block_hash });
 
-    // for (tx_id, output, idx) in block_recovery.outputs {
-    //     db.insert_tx_output(tx_id.inner(), idx, &output)
-    //         .map_err(BlockChainError::FailedToInsertTransactionOutput)?;
-    // }
+    // Revert all transactions (outputs) in the block
+    for tx in &block.transactions {
+        let mut ops = revert_tx(tx)?;
+        data_operations.append(&mut ops);
+    }
 
-    // Ok(block)
+    let block_recovery = recovery_store
+        .remove(&block_hash)
+        .unwrap_or_else(|| unreachable!("Block recovery data not found"));
 
-    todo!()
+    // Recover all removed transactions (outputs).
+    for (tx_id, output, idx) in block_recovery.outputs {
+        data_operations.push(DatabaseOperation::InsertTxOutput { tx_id, idx, output });
+    }
+
+    db.transactional_ops(data_operations)
+        .map_err(|db_err| BlockChainError::FailedToRevertBlock(block_hash, db_err))?;
+
+    Ok(block)
 }
 
-fn revert_tx(_tx: &Transaction, _db: &Database) -> Result<(), BlockChainError> {
-    // for idx in 0..tx.outputs.len() {
-    //     db.remove_tx_output(tx.id.inner(), idx)
-    //         .map_err(BlockChainError::FailedToRemoveTransactionOutput)?;
-    // }
+fn revert_tx(tx: &Transaction) -> Result<Vec<DatabaseOperation>, BlockChainError> {
+    let mut data_operations = Vec::with_capacity(tx.outputs.len());
+    for idx in 0..tx.outputs.len() {
+        data_operations.push(DatabaseOperation::RemoveTxOutput {
+            tx_id: tx.id.inner(),
+            idx,
+        });
+    }
 
-    // Ok(())
-
-    todo!()
+    Ok(data_operations)
 }
 
 /// Validates a block.
@@ -199,6 +214,381 @@ fn now_secs() -> u64 {
 /// from the state data to recover it in case of a reorg.
 #[derive(Debug, Clone, Default)]
 pub struct BlockRecoveryData {
-    // todo [sab] use `TransactionId`?
+    // TODO: use `TransactionId`?
     outputs: Vec<(Hash256, TransactionOutput, usize)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        crypto::{PrivateKey, PublicKey},
+        transaction::{GROK, TransactionId, TransactionInput},
+    };
+
+    fn prepare_chain() -> (Database, Hash256, TransactionId, TestTxCreator) {
+        let db = Database::create_test_db();
+        let (tx_creator, genesis_tx) = TestTxCreator::new();
+        let genesis_tx_id = genesis_tx.id;
+
+        let genesis_block = Block {
+            previous_block_hash: Hash256::new([0u8; 32]),
+            block_number: 0,
+            block_timestamp: now_secs(),
+            transactions: vec![genesis_tx],
+        };
+        let block_hash = Block::block_hash(&genesis_block).expect("failed to hash genesis block");
+
+        apply_block(genesis_block, &db, &mut Default::default())
+            .expect("failed to apply genesis block");
+
+        (db, block_hash, genesis_tx_id, tx_creator)
+    }
+
+    fn assert_blocks(db: &Database, blocks: Vec<(Hash256, Block)>) {
+        for (block_hash, block) in blocks {
+            let db_block = db.block(block_hash).expect("failed to get block from db");
+            assert_eq!(db_block, block);
+        }
+    }
+
+    fn assert_output(
+        db: &Database,
+        tx_id: TransactionId,
+        idx: usize,
+        expected_owner: &PublicKey,
+        amount: u64,
+    ) {
+        let output = db
+            .tx_output(tx_id.inner(), idx)
+            .expect("failed to get tx output");
+
+        assert_eq!(output.amount, amount);
+        assert_eq!(&output.ownership, expected_owner);
+    }
+
+    /// A helper struct to create test transactions.
+    ///
+    /// It's main purpose is to manage key pairs and output ownerships to easily
+    /// create valid transactions.
+    struct TestTxCreator {
+        owners: BTreeMap<PublicKey, PrivateKey>,
+        outputs: BTreeMap<(TransactionId, usize), (PrivateKey, [u8; 32])>,
+    }
+
+    impl TestTxCreator {
+        /// Creates a new test transaction creator with a random key pair
+        /// and a genesis transaction.
+        #[allow(clippy::new_without_default)]
+        fn new() -> (Self, Transaction) {
+            let pk = PrivateKey::random();
+            let pub_key = pk.public_key();
+
+            let mut owners = BTreeMap::new();
+            owners.insert(pub_key.clone(), pk.clone());
+            let outputs = BTreeMap::new();
+
+            let mut this = Self { owners, outputs };
+            let tx = this.create_tx((vec![], vec![(1000 * GROK, pub_key.clone())]));
+
+            (this, tx)
+        }
+
+        fn create_acc(&mut self) -> PublicKey {
+            let pk = PrivateKey::random();
+            let pub_key = pk.public_key();
+
+            self.owners.insert(pub_key.clone(), pk);
+
+            pub_key
+        }
+
+        #[allow(clippy::type_complexity)]
+        fn create_tx(
+            &mut self,
+            data: (Vec<(TransactionId, usize)>, Vec<(u64, PublicKey)>),
+        ) -> Transaction {
+            let mut inputs = Vec::new();
+            let mut outputs = Vec::new();
+
+            let (input_ids, outputs_data) = data;
+            for (input_id, idx) in input_ids {
+                let input = self.create_input(input_id, idx);
+                inputs.push(input);
+            }
+            for (amount, to) in outputs_data {
+                let output = self.create_output(amount, to);
+                outputs.push(output);
+            }
+
+            let tx = Transaction::new(inputs, outputs).expect("failed to create transaction");
+
+            for (idx, output) in tx.outputs.iter().enumerate() {
+                let pk = self
+                    .owners
+                    .get(&output.ownership)
+                    .expect("owner private key not found")
+                    .clone();
+                self.outputs.insert((tx.id, idx), (pk, output.challenge));
+            }
+
+            tx
+        }
+
+        fn create_input(&self, output_id: TransactionId, idx: usize) -> TransactionInput {
+            let (pk, output_challenge) = self
+                .outputs
+                .get(&(output_id, idx))
+                .expect("output challenge not found");
+            let signature = pk
+                .sign(output_challenge)
+                .expect("failed to sign output challenge");
+
+            TransactionInput {
+                tx_id: output_id,
+                idx,
+                signature,
+            }
+        }
+
+        fn create_output(&mut self, amount: u64, to: PublicKey) -> TransactionOutput {
+            TransactionOutput {
+                amount,
+                ownership: to,
+                challenge: rand::random(),
+            }
+        }
+    }
+
+    #[test]
+    fn apply_revert_basic() {
+        let (db, genesis_block_hash, genesis_tx_id, mut tx_creator) = prepare_chain();
+        let mut recovery_data = BTreeMap::new();
+
+        let pub_key1 = tx_creator.create_acc();
+        let pub_key2 = tx_creator.create_acc();
+
+        // Apply block 1
+        let transaction_1 = tx_creator.create_tx((
+            vec![(genesis_tx_id, 0)],
+            vec![
+                (200 * GROK, pub_key1.clone()),
+                (200 * GROK, pub_key2.clone()),
+                (200 * GROK, pub_key1.clone()),
+            ],
+        ));
+        let transaction_1_id = transaction_1.id;
+
+        let block_1 = Block {
+            previous_block_hash: genesis_block_hash,
+            block_number: 1,
+            block_timestamp: now_secs(),
+            transactions: vec![transaction_1],
+        };
+        let block_1_hash = Block::block_hash(&block_1).expect("failed to hash block 1");
+
+        assert!(apply_block(block_1.clone(), &db, &mut recovery_data).is_ok());
+
+        // Check the state
+        assert_output(&db, transaction_1_id, 0, &pub_key1, 200 * GROK);
+        assert_output(&db, transaction_1_id, 1, &pub_key2, 200 * GROK);
+        assert_output(&db, transaction_1_id, 2, &pub_key1, 200 * GROK);
+        assert_blocks(&db, vec![(block_1_hash, block_1.clone())]);
+        assert_eq!(db.blocks_count(), 2);
+        assert_eq!(db.transactions_count(), 3);
+
+        // Apply block 2
+        let transaction_2 = tx_creator.create_tx((
+            vec![(transaction_1_id, 0)],
+            vec![
+                (150 * GROK, pub_key2.clone()),
+                (50 * GROK, pub_key1.clone()),
+            ],
+        ));
+        let transaction_2_id = transaction_2.id;
+        let transaction_3 = tx_creator.create_tx((
+            vec![(transaction_1_id, 1)],
+            vec![
+                (100 * GROK, pub_key1.clone()),
+                (100 * GROK, pub_key2.clone()),
+            ],
+        ));
+        let transaction_3_id = transaction_3.id;
+
+        let block_2 = Block {
+            previous_block_hash: block_1_hash,
+            block_number: 2,
+            block_timestamp: now_secs(),
+            transactions: vec![transaction_2, transaction_3],
+        };
+        let block_2_hash = Block::block_hash(&block_2).expect("failed to hash block 2");
+        assert!(apply_block(block_2.clone(), &db, &mut recovery_data).is_ok());
+
+        // Check the state
+        assert_blocks(
+            &db,
+            vec![
+                (block_1_hash, block_1.clone()),
+                (block_2_hash, block_2.clone()),
+            ],
+        );
+        assert_output(&db, transaction_2_id, 0, &pub_key2, 150 * GROK);
+        assert_output(&db, transaction_2_id, 1, &pub_key1, 50 * GROK);
+        assert_output(&db, transaction_3_id, 0, &pub_key1, 100 * GROK);
+        assert_output(&db, transaction_3_id, 1, &pub_key2, 100 * GROK);
+        assert_output(&db, transaction_1_id, 2, &pub_key1, 200 * GROK);
+        assert_eq!(db.blocks_count(), 3);
+        assert_eq!(db.transactions_count(), 5);
+
+        assert!(db.tx_output(transaction_1_id.inner(), 0).is_err());
+        assert!(db.tx_output(transaction_1_id.inner(), 1).is_err());
+
+        // Revert block-2
+        let reverted_block =
+            revert_block(block_2_hash, &db, &mut recovery_data).expect("failed to revert block 2");
+        assert_eq!(reverted_block, block_2);
+
+        // Check the state
+        assert_eq!(db.blocks_count(), 2);
+        assert_eq!(db.transactions_count(), 3);
+        assert_blocks(&db, vec![(block_1_hash, block_1.clone())]);
+        assert_output(&db, transaction_1_id, 0, &pub_key1, 200 * GROK);
+        assert_output(&db, transaction_1_id, 1, &pub_key2, 200 * GROK);
+        assert_output(&db, transaction_1_id, 2, &pub_key1, 200 * GROK);
+    }
+
+    #[test]
+    fn apply_block_fails() {
+        let (db, genesis_block_hash, genesis_tx_id, mut tx_creator) = prepare_chain();
+        let mut recovery_data = BTreeMap::new();
+
+        let pub_key1 = tx_creator.create_acc();
+
+        // Apply block 1 successfully
+        let transaction_1 = tx_creator.create_tx((
+            vec![(genesis_tx_id, 0)],
+            vec![(500 * GROK, pub_key1.clone())],
+        ));
+        let transaction_1_id = transaction_1.id;
+
+        let block_1 = Block {
+            previous_block_hash: genesis_block_hash,
+            block_number: 1,
+            block_timestamp: now_secs(),
+            transactions: vec![transaction_1],
+        };
+        let block_1_hash = Block::block_hash(&block_1).expect("failed to hash block 1");
+
+        assert!(apply_block(block_1.clone(), &db, &mut recovery_data).is_ok());
+
+        // Check the state after block 1
+        assert_output(&db, transaction_1_id, 0, &pub_key1, 500 * GROK);
+        assert_blocks(&db, vec![(block_1_hash, block_1.clone())]);
+        assert_eq!(db.blocks_count(), 2);
+        assert_eq!(db.transactions_count(), 1);
+
+        // Try to apply block 2 with a transaction that tries to spend an already-spent output
+        let invalid_transaction = tx_creator.create_tx((
+            vec![(genesis_tx_id, 0)], // This output was already spent in block 1
+            vec![(300 * GROK, pub_key1.clone())],
+        ));
+
+        let block_2 = Block {
+            previous_block_hash: block_1_hash,
+            block_number: 2,
+            block_timestamp: now_secs(),
+            transactions: vec![invalid_transaction],
+        };
+        let block_2_hash = Block::block_hash(&block_2).expect("failed to hash block 2");
+
+        // This should fail because the output was already spent
+        let result = apply_block(block_2.clone(), &db, &mut recovery_data);
+        assert!(result.is_err());
+        let BlockChainError::FailedToApplyBlock(block_hash, db_err) = result.unwrap_err() else {
+            panic!("Expected InvalidTransaction error");
+        };
+        assert_eq!(block_hash, block_2_hash);
+        let DatabaseError::TransactionOutputNotFound(tx_id) =
+            db_err.transaction_inner_error().unwrap()
+        else {
+            panic!("Expected TransactionOutputNotFound error");
+        };
+        assert_eq!(tx_id, &genesis_tx_id.inner());
+
+        // Verify that the state remains unchanged (block 2 was not applied)
+        assert_eq!(db.blocks_count(), 2);
+        assert_eq!(db.transactions_count(), 1);
+        assert!(db.block(block_2_hash).is_err());
+        assert_output(&db, transaction_1_id, 0, &pub_key1, 500 * GROK);
+        assert_blocks(&db, vec![(block_1_hash, block_1.clone())]);
+    }
+
+    #[test]
+    fn revert_block_fails() {
+        let (db, genesis_block_hash, genesis_tx_id, mut tx_creator) = prepare_chain();
+        let mut recovery_data = BTreeMap::new();
+
+        let pub_key1 = tx_creator.create_acc();
+        let pub_key2 = tx_creator.create_acc();
+
+        // Apply block 1 with multiple outputs
+        let transaction_1 = tx_creator.create_tx((
+            vec![(genesis_tx_id, 0)],
+            vec![
+                (400 * GROK, pub_key1.clone()),
+                (300 * GROK, pub_key2.clone()),
+            ],
+        ));
+        let transaction_1_id = transaction_1.id;
+
+        let block_1 = Block {
+            previous_block_hash: genesis_block_hash,
+            block_number: 1,
+            block_timestamp: now_secs(),
+            transactions: vec![transaction_1],
+        };
+        let block_1_hash = Block::block_hash(&block_1).expect("failed to hash block 1");
+
+        assert!(apply_block(block_1.clone(), &db, &mut recovery_data).is_ok());
+
+        // Check the state after applying block 1
+        assert_output(&db, transaction_1_id, 0, &pub_key1, 400 * GROK);
+        assert_output(&db, transaction_1_id, 1, &pub_key2, 300 * GROK);
+        assert_blocks(&db, vec![(block_1_hash, block_1.clone())]);
+        assert_eq!(db.blocks_count(), 2);
+        assert_eq!(db.transactions_count(), 2);
+
+        // Manually remove one of the outputs created by block 1
+        // This simulates database corruption or concurrent modification
+        db.remove_tx_output(transaction_1_id.inner(), 0)
+            .expect("failed to remove output");
+
+        // Verify the output was removed
+        assert!(db.tx_output(transaction_1_id.inner(), 0).is_err());
+        assert_eq!(db.transactions_count(), 1);
+
+        // Attempt to revert block 1
+        // This should fail because one of the outputs that needs to be removed is missing
+        let result = revert_block(block_1_hash, &db, &mut recovery_data);
+
+        // The revert should fail with a database error
+        assert!(result.is_err());
+        let BlockChainError::FailedToRevertBlock(hash, db_err) = result.unwrap_err() else {
+            panic!("Expected FailedToRevertBlock error");
+        };
+        assert_eq!(hash, block_1_hash);
+        let DatabaseError::TransactionOutputNotFound(tx_id) =
+            db_err.transaction_inner_error().unwrap()
+        else {
+            panic!("Expected TransactionOutputNotFound error");
+        };
+        assert_eq!(tx_id, &transaction_1_id.inner());
+    }
+
+    /*
+       Cases:
+       1. apply 3 blocks, revert last one, check block states and tx states
+       2. apply 1 block, second apply fails
+       3. apply 1 block, revert fails
+    */
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -40,7 +40,7 @@ pub fn apply_block(
         .transactional_ops(data_operations)
         .map_err(|db_err| BlockChainError::FailedToApplyBlock(block_hash, db_err))?;
 
-    // todo [sab] recovery storage is tightly connected to transaction. It must be changed even inside the transaction
+    // TODO: issue #11
     // Store removed data for recovery in case of a reorg.
     for outcome in outcomes {
         let DatabaseOperationOutcome::RemoveTxOutput { tx_id, idx, output } = outcome else {
@@ -69,7 +69,7 @@ fn apply_tx(tx: &Transaction) -> Result<Vec<DatabaseOperation>, BlockChainError>
     }
 
     for (idx, output) in tx.outputs.iter().enumerate() {
-        // todo [sab] get rid of clone
+        // TODO: issue #12
         data_operations.push(DatabaseOperation::InsertTxOutput {
             tx_id: tx.id.inner(),
             idx,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -217,7 +217,7 @@ impl Signature {
 /// SHA-256 hash wrapper.
 ///
 /// Basically a newtype around a 32-byte array representing a SHA-256 hash.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Hash256([u8; 32]);
 
 impl Hash256 {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -53,6 +53,20 @@ impl PrivateKey {
             })
             .map_err(CryptoError::MessageSigningFailed)
     }
+
+    /// Derives the corresponding public key from the private key.
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey::from(self)
+    }
+
+    /// Converts the private key to a 32-byte array.
+    ///
+    /// # Safety
+    /// This function exposes the raw bytes of the private key.
+    /// Use with caution to avoid leaking sensitive information.
+    pub(crate) unsafe fn to_bytes_unchecked(&self) -> [u8; 32] {
+        self.0.to_bytes().into()
+    }
 }
 
 /// Public key.
@@ -67,7 +81,7 @@ impl PrivateKey {
 ///
 /// Public keys can be safely shared. They are actively used to verify signatures created by
 /// the corresponding private key and to derive blockchain addresses.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PublicKey(K256PublicKey);
 
 impl PublicKey {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,137 @@
+// Copyright 2025 Sabaun Taraki
+// SPDX-License-Identifier: Apache-2.0
+
+//! Database functionalities for Grok Chain.
+
+// todo [sab]:
+// - txs - separate tree
+// db dependant on sled
+
+// TODO: temporarily
+#![allow(dead_code)]
+
+use crate::{block::Block, codec, crypto::Hash256, errors::DatabaseError, transaction::TransactionOutput};
+
+const TX_OUTPUT_KEY_PREFIX: &str = "tx_output";
+const BLOCK_KEY_PREFIX: &str = "block";
+
+pub enum DatabaseKeys {
+    Block(Hash256),
+    TxOutput(Hash256, usize),
+}
+
+impl DatabaseKeys {
+    pub fn into_db_key(self) -> Vec<u8> {
+        match self {
+            // "block:{block_hash}"
+            DatabaseKeys::Block(block_hash) => [
+                BLOCK_KEY_PREFIX.as_bytes(),
+                b":",
+                block_hash.to_bytes().as_ref(),
+            ]
+            .concat(),
+            // "tx_output:{tx_id}:{idx}"
+            DatabaseKeys::TxOutput(tx_id, idx) => [
+                TX_OUTPUT_KEY_PREFIX.as_bytes(),
+                b":",
+                tx_id.to_bytes().as_ref(),
+                b":",
+                &idx.to_be_bytes(),
+            ]
+            .concat(),
+        }
+    }
+}
+
+pub struct Database {
+    db: sled::Db,
+}
+
+impl Database {
+    pub fn new(path: &str) -> Result<Self, DatabaseError> {
+        let db = sled::open(path).map_err(DatabaseError::OpenFailed)?;
+
+        Ok(Self { db })
+    }
+
+    pub fn block(&self, block_hash: Hash256) -> Result<Block, DatabaseError> {
+        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let block_bytes = self
+            .db
+            .get(key)
+            .map_err(DatabaseError::CannotGetBlock)?
+            .ok_or(DatabaseError::BlockNotFound(block_hash))?;
+
+        codec::decode::<Block>(block_bytes.as_ref())
+            .map_err(|codec_err| DatabaseError::FailedBlockDeserialization(block_hash, codec_err))
+    }
+
+    pub fn insert_block(&self, block_hash: Hash256, block: Block) -> Result<(), DatabaseError> {
+        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let block_bytes = codec::encode(&block)
+            .map_err(|codec_err| DatabaseError::FailedBlockSerialization(block_hash, codec_err))?;
+
+        self.db
+            .insert(key, block_bytes)
+            .map_err(DatabaseError::FailedBlockInsertion)?;
+
+        Ok(())
+    }
+
+    pub fn tx_output(
+        &self,
+        tx_id: Hash256,
+        idx: Option<usize>,
+    ) -> Result<TransactionOutput, DatabaseError> {
+        let idx = idx.unwrap_or(0);
+        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
+        let tx_output_bytes = self
+            .db
+            .get(key)
+            .map_err(DatabaseError::CannotGetTxOutput)?
+            .ok_or(DatabaseError::TransactionOutputNotFound(tx_id))?;
+
+        codec::decode::<TransactionOutput>(tx_output_bytes.as_ref())
+            .map_err(|codec_err| DatabaseError::FailedTxOutputDeserialization(tx_id, codec_err))
+    }
+
+    pub fn insert_tx_output(
+        &self,
+        tx_id: Hash256,
+        idx: usize,
+        output: &TransactionOutput,
+    ) -> Result<(), DatabaseError> {
+        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
+        let output_bytes = codec::encode(output)
+            .map_err(|codec_err| DatabaseError::FailedTxOutputSerialization(tx_id, codec_err))?;
+
+        self.db
+            .insert(key, output_bytes)
+            .map_err(DatabaseError::FailedTxOutputInsertion)?;
+        Ok(())
+    }
+
+    pub fn remove_tx_output(
+        &self,
+        tx_id: Hash256,
+        idx: usize,
+    ) -> Result<(), DatabaseError> {
+        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
+        self.db
+            .remove(key)
+            .map_err(DatabaseError::CannotGetTxOutput)?;
+
+        Ok(())
+    }
+
+    pub fn remove_block(&self, block_hash: Hash256) -> Result<Block, DatabaseError> {
+        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let v = self.db
+            .remove(key)
+            .map_err(DatabaseError::CannotGetBlock)?
+            .ok_or(DatabaseError::BlockNotFound(block_hash))?;
+
+        codec::decode::<Block>(v.as_ref())
+            .map_err(|codec_err| DatabaseError::FailedBlockDeserialization(block_hash, codec_err))
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,7 +10,9 @@
 // TODO: temporarily
 #![allow(dead_code)]
 
-use crate::{block::Block, codec, crypto::Hash256, errors::DatabaseError, transaction::TransactionOutput};
+use crate::{
+    block::Block, codec, crypto::Hash256, errors::DatabaseError, transaction::TransactionOutput,
+};
 
 const TX_OUTPUT_KEY_PREFIX: &str = "tx_output";
 const BLOCK_KEY_PREFIX: &str = "block";
@@ -111,11 +113,7 @@ impl Database {
         Ok(())
     }
 
-    pub fn remove_tx_output(
-        &self,
-        tx_id: Hash256,
-        idx: usize,
-    ) -> Result<(), DatabaseError> {
+    pub fn remove_tx_output(&self, tx_id: Hash256, idx: usize) -> Result<(), DatabaseError> {
         let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
         self.db
             .remove(key)
@@ -126,7 +124,8 @@ impl Database {
 
     pub fn remove_block(&self, block_hash: Hash256) -> Result<Block, DatabaseError> {
         let key = DatabaseKeys::Block(block_hash).into_db_key();
-        let v = self.db
+        let v = self
+            .db
             .remove(key)
             .map_err(DatabaseError::CannotGetBlock)?
             .ok_or(DatabaseError::BlockNotFound(block_hash))?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -90,7 +90,7 @@ impl Database {
             return Ok(Vec::new());
         }
 
-        // todo [sab] it has copy-paste smell with other fns in Database
+        // TODO: issue #13
         let run_transaction = |trees: (&Tree, &Tree), ops: Vec<DatabaseOperation>| {
             <(&Tree, &Tree) as Transactional<DatabaseError>>::transaction(
                 &trees,

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,9 +3,8 @@
 
 //! Database functionalities for Grok Chain.
 
-// todo [sab]:
-// - txs - separate tree
-// db dependant on sled
+// TODO:
+// 1. DB is dependant on sled right now. Abstract it away later.
 
 // TODO: temporarily
 #![allow(dead_code)]
@@ -14,52 +13,30 @@ use crate::{
     block::Block, codec, crypto::Hash256, errors::DatabaseError, transaction::TransactionOutput,
 };
 
-const TX_OUTPUT_KEY_PREFIX: &str = "tx_output";
-const BLOCK_KEY_PREFIX: &str = "block";
-
-pub enum DatabaseKeys {
-    Block(Hash256),
-    TxOutput(Hash256, usize),
-}
-
-impl DatabaseKeys {
-    pub fn into_db_key(self) -> Vec<u8> {
-        match self {
-            // "block:{block_hash}"
-            DatabaseKeys::Block(block_hash) => [
-                BLOCK_KEY_PREFIX.as_bytes(),
-                b":",
-                block_hash.to_bytes().as_ref(),
-            ]
-            .concat(),
-            // "tx_output:{tx_id}:{idx}"
-            DatabaseKeys::TxOutput(tx_id, idx) => [
-                TX_OUTPUT_KEY_PREFIX.as_bytes(),
-                b":",
-                tx_id.to_bytes().as_ref(),
-                b":",
-                &idx.to_be_bytes(),
-            ]
-            .concat(),
-        }
-    }
-}
-
 pub struct Database {
-    db: sled::Db,
+    blocks_tree: sled::Tree,
+    txs_tree: sled::Tree,
 }
 
 impl Database {
     pub fn new(path: &str) -> Result<Self, DatabaseError> {
         let db = sled::open(path).map_err(DatabaseError::OpenFailed)?;
 
-        Ok(Self { db })
+        let blocks_tree = db.open_tree("blocks").map_err(DatabaseError::OpenFailed)?;
+        let txs_tree = db
+            .open_tree("tx_outputs")
+            .map_err(DatabaseError::OpenFailed)?;
+
+        Ok(Self {
+            blocks_tree,
+            txs_tree,
+        })
     }
 
     pub fn block(&self, block_hash: Hash256) -> Result<Block, DatabaseError> {
-        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let key = block_hash.to_bytes();
         let block_bytes = self
-            .db
+            .blocks_tree
             .get(key)
             .map_err(DatabaseError::CannotGetBlock)?
             .ok_or(DatabaseError::BlockNotFound(block_hash))?;
@@ -69,11 +46,11 @@ impl Database {
     }
 
     pub fn insert_block(&self, block_hash: Hash256, block: Block) -> Result<(), DatabaseError> {
-        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let key = block_hash.to_bytes();
         let block_bytes = codec::encode(&block)
             .map_err(|codec_err| DatabaseError::FailedBlockSerialization(block_hash, codec_err))?;
 
-        self.db
+        self.blocks_tree
             .insert(key, block_bytes)
             .map_err(DatabaseError::FailedBlockInsertion)?;
 
@@ -83,12 +60,11 @@ impl Database {
     pub fn tx_output(
         &self,
         tx_id: Hash256,
-        idx: Option<usize>,
+        idx: usize,
     ) -> Result<TransactionOutput, DatabaseError> {
-        let idx = idx.unwrap_or(0);
-        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
+        let key = self.tx_key(tx_id, idx);
         let tx_output_bytes = self
-            .db
+            .txs_tree
             .get(key)
             .map_err(DatabaseError::CannotGetTxOutput)?
             .ok_or(DatabaseError::TransactionOutputNotFound(tx_id))?;
@@ -103,34 +79,216 @@ impl Database {
         idx: usize,
         output: &TransactionOutput,
     ) -> Result<(), DatabaseError> {
-        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
+        let key = self.tx_key(tx_id, idx);
         let output_bytes = codec::encode(output)
             .map_err(|codec_err| DatabaseError::FailedTxOutputSerialization(tx_id, codec_err))?;
 
-        self.db
+        self.txs_tree
             .insert(key, output_bytes)
             .map_err(DatabaseError::FailedTxOutputInsertion)?;
         Ok(())
     }
 
     pub fn remove_tx_output(&self, tx_id: Hash256, idx: usize) -> Result<(), DatabaseError> {
-        let key = DatabaseKeys::TxOutput(tx_id, idx).into_db_key();
-        self.db
+        let key = self.tx_key(tx_id, idx);
+        self.txs_tree
             .remove(key)
-            .map_err(DatabaseError::CannotGetTxOutput)?;
+            .map_err(DatabaseError::CannotGetTxOutput)?
+            .ok_or(DatabaseError::TransactionOutputNotFound(tx_id))?;
 
         Ok(())
     }
 
     pub fn remove_block(&self, block_hash: Hash256) -> Result<Block, DatabaseError> {
-        let key = DatabaseKeys::Block(block_hash).into_db_key();
+        let key = block_hash.to_bytes();
         let v = self
-            .db
+            .blocks_tree
             .remove(key)
             .map_err(DatabaseError::CannotGetBlock)?
             .ok_or(DatabaseError::BlockNotFound(block_hash))?;
 
         codec::decode::<Block>(v.as_ref())
             .map_err(|codec_err| DatabaseError::FailedBlockDeserialization(block_hash, codec_err))
+    }
+
+    fn tx_key(&self, tx_id: Hash256, idx: usize) -> Vec<u8> {
+        [tx_id.to_bytes().as_ref(), &idx.to_be_bytes()].concat()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::{PrivateKey, PublicKey};
+
+    fn create_test_db() -> Database {
+        let db = sled::Config::new()
+            .temporary(true)
+            .open()
+            .expect("Failed to create temp db");
+
+        let blocks_tree = db.open_tree("blocks").expect("Failed to open blocks tree");
+        let txs_tree = db
+            .open_tree("tx_outputs")
+            .expect("Failed to open tx_outputs tree");
+
+        Database {
+            blocks_tree,
+            txs_tree,
+        }
+    }
+
+    // Helper to create a dummy block
+    fn dummy_block(bn: u32, timestamp: u64) -> Block {
+        Block {
+            previous_block_hash: Hash256::new(b"prev"),
+            block_number: bn,
+            block_timestamp: timestamp,
+            transactions: vec![],
+        }
+    }
+
+    // Helper to create a dummy transaction output with custom params
+    fn dummy_tx_output(amount: u64, key_seed: u8) -> TransactionOutput {
+        let private_key = PrivateKey::from_bytes(&[key_seed; 32]).unwrap();
+        TransactionOutput {
+            amount,
+            ownership: PublicKey::from(&private_key),
+            challenge: [0u8; 32],
+        }
+    }
+
+    #[test]
+    fn test_block_access() {
+        let db = create_test_db();
+
+        // Test 1: non-existent block
+        let hash = Hash256::new(b"nonexistent");
+        let result = db.block(hash);
+        assert!(matches!(result, Err(DatabaseError::BlockNotFound(_))));
+
+        // Test 2: invalid bytes
+        let hash = Hash256::new(b"invalid");
+        db.blocks_tree
+            .insert(hash.to_bytes(), b"invalid_data")
+            .expect("Failed to insert");
+        let result = db.block(hash);
+        assert!(result.is_err());
+
+        // Test 3: existent block
+        let hash = Hash256::new(b"block1");
+        let block = dummy_block(1, 100);
+        db.insert_block(hash, block.clone())
+            .expect("Failed to insert block");
+        let retrieved = db.block(hash).expect("Failed to retrieve block");
+        assert_eq!(retrieved.block_number, block.block_number);
+        assert_eq!(retrieved.block_timestamp, block.block_timestamp);
+    }
+
+    #[test]
+    fn test_block_remove_and_inaccessible() {
+        let db = create_test_db();
+        let hash = Hash256::new(b"block2");
+        let block = dummy_block(1, 100);
+
+        db.insert_block(hash, block)
+            .expect("Failed to insert block");
+        db.remove_block(hash).expect("Failed to remove block");
+
+        let result = db.block(hash);
+        assert!(matches!(result, Err(DatabaseError::BlockNotFound(_))));
+    }
+
+    #[test]
+    fn test_block_reset_on_overwrite() {
+        let db = create_test_db();
+        let hash = Hash256::new(b"block3");
+
+        let block1 = dummy_block(1, 100);
+        let block2 = dummy_block(2, 100);
+
+        db.insert_block(hash, block1)
+            .expect("Failed to insert block1");
+        db.insert_block(hash, block2)
+            .expect("Failed to insert block2");
+
+        let retrieved = db.block(hash).expect("Failed to retrieve block");
+        assert_eq!(retrieved.block_number, 2);
+    }
+
+    #[test]
+    fn test_tx_access() {
+        let db = create_test_db();
+
+        // Test 1: non-existent tx hash
+        let tx_id = Hash256::new(b"nonexistent_tx");
+        let result = db.tx_output(tx_id, 0);
+        assert!(matches!(
+            result,
+            Err(DatabaseError::TransactionOutputNotFound(_))
+        ));
+
+        // Test 2: invalid bytes
+        let tx_id = Hash256::new(b"tx_invalid");
+        let key = [tx_id.to_bytes().as_ref(), &0usize.to_be_bytes()].concat();
+        db.txs_tree
+            .insert(key, b"invalid_tx_data")
+            .expect("Failed to insert");
+        let result = db.tx_output(tx_id, 0);
+        assert!(result.is_err());
+
+        // Test 3: valid existent tx
+        let tx_id = Hash256::new(b"tx_valid");
+        let output = dummy_tx_output(1000, 1);
+        db.insert_tx_output(tx_id, 0, &output)
+            .expect("Failed to insert tx output");
+        let retrieved = db.tx_output(tx_id, 0).expect("Failed to retrieve tx");
+        assert_eq!(retrieved.amount, output.amount);
+        assert_eq!(retrieved.challenge, output.challenge);
+
+        // Test 4: non-existent index (correct tx_id, wrong idx)
+        let result = db.tx_output(tx_id, 1);
+        assert!(matches!(
+            result,
+            Err(DatabaseError::TransactionOutputNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_tx_remove_and_inaccessible() {
+        let db = create_test_db();
+        let tx_id = Hash256::new(b"tx4");
+        let output = dummy_tx_output(1000, 1);
+
+        db.insert_tx_output(tx_id, 0, &output)
+            .expect("Failed to insert tx output");
+        assert!(db.remove_tx_output(tx_id, 1).is_err());
+        assert!(db.tx_output(tx_id, 0).is_ok());
+
+        db.remove_tx_output(tx_id, 0)
+            .expect("Failed to remove tx output");
+
+        let result = db.tx_output(tx_id, 0);
+        assert!(matches!(
+            result,
+            Err(DatabaseError::TransactionOutputNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_tx_reset_on_overwrite() {
+        let db = create_test_db();
+        let tx_id = Hash256::new(b"tx5");
+
+        let output1 = dummy_tx_output(1000, 1);
+        let output2 = dummy_tx_output(2000, 2);
+
+        db.insert_tx_output(tx_id, 0, &output1)
+            .expect("Failed to insert tx output1");
+        db.insert_tx_output(tx_id, 0, &output2)
+            .expect("Failed to insert tx output2");
+
+        let retrieved = db.tx_output(tx_id, 0).expect("Failed to retrieve tx");
+        assert_eq!(retrieved.amount, 2000);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,6 @@
 // TODO: temporarily
 #![allow(dead_code)]
 
-use core::error;
-
 use crate::crypto::Hash256;
 
 /// General grok chain error.
@@ -98,8 +96,8 @@ pub enum BlockChainError {
     CannotGetBlock(Hash256, DatabaseError),
     #[error("Orphan block received with hash {0:?}")]
     OrphanBlockReceived(Hash256),
-    #[error("Invalid transaction {0:?}: {1}")]
-    InvalidTransaction(Hash256, TransactionError),
+    #[error("Invalid transaction {0:?}")]
+    InvalidTransaction(Box<(Hash256, TransactionError)>),
     #[error("Failed to serialize block: {0}")]
     FailedBlockSerialization(CodecError),
     #[error("Failed to store block to db: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@
 
 //! Error definitions for Grok Chain.
 
-// TODO [sab]:
+// TODO:
 // 1. Huge design mistake - every error depends too much on underlying error type
 // 2. Database errors aren't unique. But uniting them makes it hard to identify the exact error.
 
@@ -89,6 +89,19 @@ pub enum DatabaseError {
     FailedTxOutputSerialization(Hash256, CodecError),
     #[error("Failed to insert transaction output into database: {0}")]
     FailedTxOutputInsertion(sled::Error),
+}
+
+impl DatabaseError {
+    #[cfg(test)]
+    pub fn transaction_inner_error(&self) -> Option<&Self> {
+        if let DatabaseError::TransactionFailed(inner) = self
+            && let sled::transaction::TransactionError::Abort(db_err) = &**inner
+        {
+            Some(db_err)
+        } else {
+            None
+        }
+    }
 }
 
 /// Block chain related errors.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,8 +3,16 @@
 
 //! Error definitions for Grok Chain.
 
+// TODO [sab]:
+// 1. Huge design mistake - every error depends too much on underlying error type
+// 2. Database errors aren't unique. But uniting them makes it hard to identify the exact error.
+
 // TODO: temporarily
 #![allow(dead_code)]
+
+use core::error;
+
+use crate::crypto::Hash256;
 
 /// General grok chain error.
 #[derive(Debug, thiserror::Error)]
@@ -27,8 +35,18 @@ pub enum CryptoError {
 /// Transaction related errors.
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionError {
-    #[error("Failed to serialize transaction: {0}")]
-    FailedTransactionSerialization(#[from] CodecError),
+    #[error("Failed to serialize transaction inputs and outputs {0:?}")]
+    FailedRawTransactionSerialization(CodecError),
+    #[error("Empty transaction: transaction ID {0:?} has either no inputs or no outputs")]
+    EmptyTransaction(Hash256),
+    #[error("Invalid transaction {0:?} signature {1:?}")]
+    InvalidSignature(Hash256, CryptoError),
+    #[error("Insufficient funds in transaction {0:?}")]
+    InsufficientFunds(Hash256),
+    #[error("Transaction output with ID {0:?} and idx {1} not found: {2:?}")]
+    TransactionOutputNotFound(Hash256, usize, DatabaseError),
+    #[error("Failed to insert transaction output with ID {0:?} and idx {1}: {2:?}")]
+    FailedToInsertTransactionOutput(Hash256, usize, DatabaseError),
 }
 
 /// Codec related errors
@@ -38,4 +56,54 @@ pub enum CodecError {
     SerializationFailed(postcard::Error),
     #[error("Failed to deserialize data: {0}")]
     DeserializationFailed(postcard::Error),
+}
+
+/// Database related errors.
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseError {
+    #[error("Failed to open database: {0}")]
+    OpenFailed(sled::Error),
+
+    // Block related errors
+    #[error("Failed to get the block {0}")]
+    CannotGetBlock(sled::Error),
+    #[error("Block with hash {0:?} not found")]
+    BlockNotFound(Hash256),
+    #[error("Failed to deserialize block with hash {0:?}: {1}")]
+    FailedBlockDeserialization(Hash256, CodecError),
+    #[error("Failed to serialize block with hash {0:?}: {1}")]
+    FailedBlockSerialization(Hash256, CodecError),
+    #[error("Failed to insert block into database: {0}")]
+    FailedBlockInsertion(sled::Error),
+
+    // Transaction output related errors
+    #[error("Failed to get the transaction output {0}")]
+    CannotGetTxOutput(sled::Error),
+    #[error("Transaction output with ID {0:?} not found")]
+    TransactionOutputNotFound(Hash256),
+    #[error("Failed to deserialize transaction output with ID {0:?}: {1}")]
+    FailedTxOutputDeserialization(Hash256, CodecError),
+    #[error("Failed to serialize transaction output with ID {0:?}: {1}")]
+    FailedTxOutputSerialization(Hash256, CodecError),
+    #[error("Failed to insert transaction output into database: {0}")]
+    FailedTxOutputInsertion(sled::Error),
+}
+
+/// Block chain related errors.
+#[derive(Debug, thiserror::Error)]
+pub enum BlockChainError {
+    #[error("Failed to add block with hash {0:?}: {1}")]
+    FailedToAddBlock(Hash256, DatabaseError),
+    #[error("Failed to get block with hash {0:?}: {1}")]
+    CannotGetBlock(Hash256, DatabaseError),
+    #[error("Orphan block received with hash {0:?}")]
+    OrphanBlockReceived(Hash256),
+    #[error("Invalid transaction {0:?}: {1}")]
+    InvalidTransaction(Hash256, TransactionError),
+    #[error("Failed to serialize block: {0}")]
+    FailedBlockSerialization(CodecError),
+    #[error("Failed to store block to db: {0}")]
+    FailedToStoreBlock(DatabaseError),
+    #[error("Failed to remove block from db: {0}")]
+    FailedToRemoveBlock(DatabaseError),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,6 +45,8 @@ pub enum TransactionError {
     TransactionOutputNotFound(Hash256, usize, DatabaseError),
     #[error("Failed to insert transaction output with ID {0:?} and idx {1}: {2:?}")]
     FailedToInsertTransactionOutput(Hash256, usize, DatabaseError),
+    #[error("Zero output transaction: transaction ID {0:?} has total output amount of zero")]
+    ZeroOutputTransaction(Hash256),
 }
 
 /// Codec related errors
@@ -104,4 +106,8 @@ pub enum BlockChainError {
     FailedToStoreBlock(DatabaseError),
     #[error("Failed to remove block from db: {0}")]
     FailedToRemoveBlock(DatabaseError),
+    #[error("Failed to insert transaction output: {0}")]
+    FailedToInsertTransactionOutput(DatabaseError),
+    #[error("Failed to remove transaction output: {0}")]
+    FailedToRemoveTransactionOutput(DatabaseError),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,6 +63,8 @@ pub enum CodecError {
 pub enum DatabaseError {
     #[error("Failed to open database: {0}")]
     OpenFailed(sled::Error),
+    #[error("Database transaction failed: {0:?}")]
+    TransactionFailed(Box<sled::transaction::TransactionError<Self>>),
 
     // Block related errors
     #[error("Failed to get the block {0}")]
@@ -102,12 +104,8 @@ pub enum BlockChainError {
     InvalidTransaction(Box<(Hash256, TransactionError)>),
     #[error("Failed to serialize block: {0}")]
     FailedBlockSerialization(CodecError),
-    #[error("Failed to store block to db: {0}")]
-    FailedToStoreBlock(DatabaseError),
-    #[error("Failed to remove block from db: {0}")]
-    FailedToRemoveBlock(DatabaseError),
-    #[error("Failed to insert transaction output: {0}")]
-    FailedToInsertTransactionOutput(DatabaseError),
-    #[error("Failed to remove transaction output: {0}")]
-    FailedToRemoveTransactionOutput(DatabaseError),
+    #[error("Failed block {0:?} application: {1:?}")]
+    FailedToApplyBlock(Hash256, DatabaseError),
+    #[error("Failed block {0:?} revert: {1:?}")]
+    FailedToRevertBlock(Hash256, DatabaseError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright 2025 Sabaun Taraki
 // SPDX-License-Identifier: Apache-2.0
 
+mod block;
 mod codec;
 mod crypto;
+mod db;
 mod errors;
 mod transaction;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -19,14 +19,14 @@ use serde::{Deserialize, Serialize};
 /// The name is inspired by Robert A. Heinlein, a science fiction author, who
 /// actually coined the term "grok", which stands for "to understand deeply and
 /// intuitively".
-const HEINLEIN: u64 = 1;
+pub const HEINLEIN: u64 = 1;
 
 /// Grok is the main currency unit.
 ///
 /// 1 Grok = 1,000,000,000 Heinleins.
 /// Heinlein is needed to avoid floating point precision issues.
 /// So 0.000000001 Grok = 1 Heinlein.
-const GROK: u64 = 1_000_000_000 * HEINLEIN;
+pub const GROK: u64 = 1_000_000_000 * HEINLEIN;
 
 /// Validates a transaction.
 ///
@@ -140,7 +140,7 @@ impl Transaction {
 ///
 /// *Note*: The identifier isn't possible to be instantiated directly, only through
 /// creating a transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct TransactionId(Hash256);
 
 impl TransactionId {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -40,8 +40,7 @@ pub fn execute_tx(tx: Transaction, db: &Database) -> Result<(), TransactionError
         let output_id = input.tx_id.inner();
         let output_idx = input.idx;
 
-        db
-            .remove_tx_output(output_id, output_idx)
+        db.remove_tx_output(output_id, output_idx)
             .map_err(|db_err| {
                 TransactionError::TransactionOutputNotFound(output_id, output_idx, db_err)
             })?;
@@ -64,12 +63,12 @@ pub fn revert_tx(tx: Transaction, db: &Database) -> Result<(), TransactionError>
     } = tx;
 
     let id = id.inner();
-    for (idx, output) in outputs.into_iter().enumerate() {
+    for (idx, _output) in outputs.into_iter().enumerate() {
         db.remove_tx_output(id, idx)
             .map_err(|db_err| TransactionError::TransactionOutputNotFound(id, idx, db_err))?;
     }
 
-    for input in inputs {
+    for _input in inputs {
         todo!("bring back spent outputs");
     }
 


### PR DESCRIPTION
This PR introduces the persistence layer and state management for our blockchain.

Before this PR, we had cryptographic primitives and transaction structures, but there was no way to actually store these transactions, execute/apply them. This PR solves all of these problems.

Let's start with some architectural note. Only in our Telegram channel did we touch upon the fundamental nature of blockchain: it is a decentralized network with no single central server. Instead, everyone acts as both a server and a client (https://t.me/grok_chain/9). This type of network architecture is known as peer-to-peer, or P2P. This P2P functionality will likely be implemented in the next Pull Request.

In a peer-to-peer network, complete chaos reigns. New transactions are constantly flooding in through your incoming connections. Therefore, before storing transactions our primary task is to establish a process for validating them.

## Transaction Validation (`src/transaction.rs`)
The `validate_tx` function performs validation checks:

#### ✅ Check №1: Non-Empty
```rust
if tx.inputs.is_empty() || tx.outputs.is_empty() {
    return Err(TransactionError::EmptyTransaction(tx_id));
}
```

Both inputs and outputs must exist.

#### ✅ Check №2: Inputs Exist in UTXO Set
```rust
let output = db.tx_output(output_id, output_idx)?;
```
Here we first time encounter a database, which will be covered later. However it should be stated now that our blockchain stores persistently a set of outputs that haven't been spent yet. Basically it's called *U*nspent *T*ransactions *O*utputs set -> a UTXO set. Now you know how the name was born. So by traversing this set we are able to know how much value an account can actually spend.

Each input must reference an *unspent* output. If it's already spent or never existed, reject the transaction.

#### ✅ Check №3: Valid Signatures
```rust
input.signature.verify(output.challenge.as_ref(), &output.ownership)?;
```

The input's signature must be valid for the output's challenge data, proving the sender owns the output. You can find more details about signature verification here - https://github.com/techraed/grok-chain/pull/4.

#### ✅ Check №4: Sufficient Funds
```rust
if total_input_sum < total_output_sum {
    return Err(TransactionError::InsufficientFunds(tx_id));
}
```

Can't spend more than you have!

#### Example Validation Flow

```text
Transaction:
  Inputs:  [TX_A:0 (100 GROK), TX_B:1 (50 GROK)]
  Outputs: [140 GROK to Bob]
  Fee:     10 GROK

Validation:
  ✓ Non-empty? Yes (1 input, 1 output)
  ✓ TX_A output 0 exists? Check UTXO set → Yes
  ✓ TX_A output 0 signature valid? Verify → Yes
  ✓ TX_B output 1 exists? Check UTXO set → Yes
  ✓ TX_B output 1 signature valid? Verify → Yes
  ✓ Total outputs > 0? Yes (140 > 0)
  ✓ Inputs ≥ outputs? Yes (150 ≥ 140)
  
  Result: VALID ✅
```

----

Alright, now we know how to deal with newly received transactions. First we validate them, then we store them. But what about their execution? Moreover, there's a crucial task of finding out what's a proper way to order these transactions. The problem here is that you can model a network of 3 nodes each of which have the same set of transactions, but they all execute them in a different order.

Can we be sure that the final state of all nodes is the same? Actually we are going too far right now, as that's the subject of the consensus, which we will cover later in other PRs. However right now we should state that nodes in the network don't just send transactions, but they also share the way they ordered them in **blocks**.

## Block Management (`src/block.rs`)

#### The Block Structure

```rust
pub struct Block {
    pub previous_block_hash: Hash256,     // Links to parent block
    pub block_number: u32,                         // Height in the chain
    pub block_timestamp: u64,                    // Unix timestamp
    pub transactions: Vec<Transaction>,    // The actual transactions
}
```

Blocks form a **linked list** through `previous_block_hash`. Block hash is basically a hash of all the fields of the block structure. Each block points to its parent, creating an immutable chain. The chain is immutable because changing any element of the block will eventually change the whole block hash.

#### Applying Blocks: A Tutorial

The `apply_block` function is the heart of blockchain state management. That's the way of executing transactions with some decided and shared. The function is called whenever a blockchain node creates a block by itself, or receives a block from the network.  Here's what it does:

**Step 1: Process All Transactions**
```rust
for tx in &block.transactions {
    let mut ops = apply_tx(tx)?;
    data_operations.append(&mut ops);
}
```

For each transaction, we generate operations to:
- Remove spent outputs (inputs)
- Create and store new outputs

**Step 2: Store the Block**
```rust
data_operations.push(DatabaseOperation::InsertBlock { block_hash, block });
```

**Step 3: Execute Atomically**
```rust
let outcomes = db.transactional_ops(data_operations)?;
```

All operations succeed together or fail together.

**Step 4: Save Recovery Data**
```rust
for outcome in outcomes {
    if let DatabaseOperationOutcome::RemoveTxOutput { tx_id, idx, output } = outcome {
        recovery_store.entry(block_hash).or_default().outputs.push((tx_id, output, idx));
    }
}
```

We save all removed outputs so we can restore them if we need to revert this block later (during chain reorganizations).

#### Reverting Blocks

The `revert_block` function:
1. Removes all outputs created by the block
2. **Restores** all outputs that were spent (from recovery store)
3. Removes the block itself

This is why we save recovery data!

---

## Database Layer (`src/db.rs`)

#### The Challenge: Atomic State Updates

Blockchains must maintain perfect consistency. Imagine applying a block with 100 transactions and crashing at transaction 50 - the blockchain would be corrupted. That's why all mutations while applying block or a transaction are done atomically.

**Transactional Operations**

```rust
pub enum DatabaseOperation {
    InsertBlock { block_hash: Hash256, block: Block },
    RemoveBlock { block_hash: Hash256 },
    InsertTxOutput { tx_id: Hash256, idx: usize, output: TransactionOutput },
    RemoveTxOutput { tx_id: Hash256, idx: usize },
}
```

Instead of mutating the database immediately (validated a transaction - write it immediately), we:
1. **Describe** what needs to change (collect operations)
2. **Execute all operations atomically** in one database transaction
3. Either **all succeed** or **none persist**

#### Example: Applying a Block

```text
Block contains 2 transactions:
  TX1: Alice spends 100 GROK → 60 to Bob, 40 to Alice
  TX2: Bob spends 60 GROK → 30 to Carol, 30 to Bob

Operations collected:
  1. Remove Alice's 100 GROK output (TX1 input)
  2. Insert Bob's 60 GROK output (TX1 output 0)
  3. Insert Alice's 40 GROK output (TX1 output 1)
  4. Remove Bob's 60 GROK output (TX2 input)
  5. Insert Carol's 30 GROK output (TX2 output 0)
  6. Insert Bob's 30 GROK output (TX2 output 1)
  7. Insert the block itself

✅ All 7 operations execute in ONE atomic transaction
```

If operation 5 fails, operations 1-4 are **automatically rolled back**. The blockchain remains in a valid state.